### PR TITLE
Add compatibility with lite-xl

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -8,11 +8,15 @@ local style = require "core.style"
 local View = require "core.view"
 local Object = require "core.object"
 
+local function is_lite_xl()
+  return core.window_mode
+end
 
 -- CONSTANTS
 local PLUGIN_PATH = system.absolute_path(USERDIR .. "/plugins")
-local PLUGIN_URL = "https://raw.githubusercontent.com/franko/lite-plugins/master/README.md"
-
+local PLUGIN_URL = is_lite_xl()
+  and "https://raw.githubusercontent.com/franko/lite-plugins/master/README.md"
+  or "https://raw.githubusercontent.com/rxi/lite-plugins/master/README.md"
 
 local ListView = View:extend()
 
@@ -598,7 +602,7 @@ local function show_plugins(plugins, callback)
 
   local v = ListView(list)
   local node = core.root_view:get_active_node()
-  if core.window_mode then -- recognise lite-xl
+  if is_lite_xl() then
     node:add_view(v)
   else
     assert(not node.locked, "Cannot open list to a locked node")

--- a/init.lua
+++ b/init.lua
@@ -1,3 +1,4 @@
+-- mod-version:1 -- lite-xl 1.16
 local core = require "core"
 local command = require "core.command"
 local common = require "core.common"
@@ -9,8 +10,8 @@ local Object = require "core.object"
 
 
 -- CONSTANTS
-local PLUGIN_PATH = system.absolute_path(EXEDIR .. "/data/plugins")
-local PLUGIN_URL = "https://raw.githubusercontent.com/rxi/lite-plugins/master/README.md"
+local PLUGIN_PATH = system.absolute_path(USERDIR .. "/plugins")
+local PLUGIN_URL = "https://raw.githubusercontent.com/franko/lite-plugins/master/README.md"
 
 
 local ListView = View:extend()
@@ -597,8 +598,12 @@ local function show_plugins(plugins, callback)
 
   local v = ListView(list)
   local node = core.root_view:get_active_node()
-  assert(not node.locked, "Cannot open list to a locked node")
-  node:split("down", v)
+  if core.window_mode then -- recognise lite-xl
+    node:add_view(v)
+  else
+    assert(not node.locked, "Cannot open list to a locked node")
+    node:split("down", v)
+  end
 
   function v:on_selected(item)
     callback(plugins[item.realname])

--- a/init.lua
+++ b/init.lua
@@ -13,10 +13,16 @@ local function is_lite_xl()
 end
 
 -- CONSTANTS
-local PLUGIN_PATH = system.absolute_path(USERDIR .. "/plugins")
-local PLUGIN_URL = is_lite_xl()
-  and "https://raw.githubusercontent.com/franko/lite-plugins/master/README.md"
-  or "https://raw.githubusercontent.com/rxi/lite-plugins/master/README.md"
+local PLUGIN_PATH, PLUGIN_REPO
+if is_lite_xl() then
+  PLUGIN_PATH = USERDIR .. "/plugins"
+  PLUGIN_REPO = "franko"
+else
+  PLUGIN_PATH = EXEDIR .. "/data/plugins"
+  PLUGIN_REPO = "rxi"
+end
+PLUGIN_PATH = system.absolute_path(PLUGIN_PATH)
+local PLUGIN_URL = "https://raw.githubusercontent.com/" .. PLUGIN_REPO .. "/lite-plugins/master/README.md"
 
 local ListView = View:extend()
 


### PR DESCRIPTION
Thank you for your work on this! If you are interested in the compatibility with `lite-xl`, this is the minimum change that I needed.

I dared to change `EXEDIR` for `USERDIR`. Were you really planning to manage plugins in the installation directory and not the plugins in your `$HOME`?